### PR TITLE
Fix conntrack issue when next record tx/rx bytes value could be lower than previous value

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 	"inet.af/netaddr"
@@ -162,9 +163,11 @@ func (c *Collector) collect() error {
 		rxPackets := conn.RxPackets
 
 		if cachedConn, found := c.entriesCache[connKey]; found {
-			txBytes -= cachedConn.TxBytes
+			// TODO: REP-243: there is known issue that current tx/rx bytes could be lower than previously scrapped values,
+			// so treat it as 0 delta to avoid random values for uint64
+			txBytes = lo.Ternary(txBytes < cachedConn.TxBytes, 0, txBytes-cachedConn.TxBytes)
+			rxBytes = lo.Ternary(rxBytes < cachedConn.RxBytes, 0, rxBytes-cachedConn.RxBytes)
 			txPackets -= cachedConn.TxPackets
-			rxBytes -= cachedConn.RxBytes
 			rxPackets -= cachedConn.RxPackets
 		}
 		c.entriesCache[connKey] = conn

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -167,8 +167,8 @@ func (c *Collector) collect() error {
 			// so treat it as 0 delta to avoid random values for uint64
 			txBytes = lo.Ternary(txBytes < cachedConn.TxBytes, 0, txBytes-cachedConn.TxBytes)
 			rxBytes = lo.Ternary(rxBytes < cachedConn.RxBytes, 0, rxBytes-cachedConn.RxBytes)
-			txPackets -= cachedConn.TxPackets
-			rxPackets -= cachedConn.RxPackets
+			txPackets = lo.Ternary(txPackets < cachedConn.TxPackets, 0, txPackets-cachedConn.TxPackets)
+			rxPackets = lo.Ternary(rxPackets < cachedConn.RxPackets, 0, rxPackets-cachedConn.RxPackets)
 		}
 		c.entriesCache[connKey] = conn
 

--- a/conntrack/nf_conntrack.go
+++ b/conntrack/nf_conntrack.go
@@ -99,7 +99,7 @@ func (n *netfilterClient) ListEntries(filter EntriesFilter) ([]*Entry, error) {
 			TxBytes:   entry.RxBytes,
 			TxPackets: entry.RxPackets,
 			RxBytes:   entry.TxBytes,
-			RxPackets: entry.RxPackets,
+			RxPackets: entry.TxPackets,
 			Proto:     entry.Proto,
 			Lifetime:  entry.Lifetime,
 		}


### PR DESCRIPTION
It is possible that during calculation of deltas between 2 consecutive conntrack entries, latest could have lower value of tx/rx bytes than previously tracked entry, so in this case let's assume that delta is 0, because otherwise we will get incorrect value