### PR TITLE
Upgrade protobuf to 1.33.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,10 +26,10 @@ jobs:
           msg=$(git show -s --format=%s)
           echo "head_commit_message=${msg}" >> $GITHUB_ENV
 
-      - name: Setup Go 1.20
+      - name: Setup Go 1.21
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Cache Go modules
         uses: actions/cache@v2
@@ -142,10 +142,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Go 1.20
+      - name: Setup Go 1.21
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Go 1.20
+      - name: Setup Go 1.21
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Cache Go modules
         uses: actions/cache@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/castai/egressd
 
-go 1.21
+go 1.21.0
+
+toolchain go1.21.6
 
 require (
 	github.com/Code-Hex/go-generics-cache v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/vishvananda/netns v0.0.4
 	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.15.0
-	google.golang.org/protobuf v1.31.0
+	google.golang.org/protobuf v1.33.0
 	gopkg.in/yaml.v3 v3.0.1
 	inet.af/netaddr v0.0.0-20220811202034-502d2d690317
 	k8s.io/api v0.27.6

--- a/go.sum
+++ b/go.sum
@@ -847,8 +847,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Avoid discovered vulnerability that is described as
```
The protojson.Unmarshal function can enter an infinite loop when 
unmarshaling certain forms of invalid JSON. This condition can 
occur when unmarshaling into a message which contains a 
google.protobuf.Any value, or when the UnmarshalOptions.DiscardUnknown 
option is set.
```

Additionaly, cilium upgrade in #104 required go 1.21, but we forgot
to update the GitHub actions, so I'm bumping the go version there too 