### PR TITLE
fix: remove obsolete YAML separator

### DIFF
--- a/charts/egressd/templates/collector/rbac.yaml
+++ b/charts/egressd/templates/collector/rbac.yaml
@@ -11,7 +11,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
The duplicated YAML separator causes the generation of an empty manifest when `helm template` is executed. This is no problem when `kubectl apply` is used, but it causes hiccups for some linters.