### PR TITLE
feat: add support for external labels

### DIFF
--- a/charts/egressd/templates/exporter/deployment.yaml
+++ b/charts/egressd/templates/exporter/deployment.yaml
@@ -56,6 +56,11 @@ spec:
         - "-{{ $key }}"
         {{- end }}
         {{- end }}
+        {{- range $key, $value := .Values.exporter.extraLabels }}
+        {{- if and $value $key }}
+        - "-extra-label={{ $key }}={{ $value }}"
+        {{- end }}
+        {{- end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/charts/egressd/values.yaml
+++ b/charts/egressd/values.yaml
@@ -198,5 +198,9 @@ exporter:
     log-level: info
   # metric-buffer-size: 10000
 
+  # Extra labels to pass along when using the Prometheus Remote-Write sink
+  extraLabels: {}
+  # mylabel: myvalue
+
   prometheusScrape:
     enabled: true

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -34,6 +34,7 @@ var (
 	logLevel       = flag.String("log-level", logrus.InfoLevel.String(), "Log level")
 	httpListenPort = flag.Int("http-listen-port", 6060, "HTTP server listen port")
 	configPath     = flag.String("config-path", "/etc/egressd/config/config.yaml", "Path to exporter config path")
+	extraLabels    = make(sinks.ExtraLabels)
 )
 
 // These should be set via `go build` during a release.
@@ -44,6 +45,7 @@ var (
 )
 
 func main() {
+	flag.Var(&extraLabels, "extra-label", "key=value pairs to set labels")
 	flag.Parse()
 
 	log := logrus.New()
@@ -130,7 +132,7 @@ func run(log logrus.FieldLogger) error {
 			))
 		} else if s.PromRemoteWriteConfig != nil {
 			sinksList = append(sinksList, sinks.NewPromRemoteWriteSink(
-				log, name, *s.PromRemoteWriteConfig,
+				log, name, *s.PromRemoteWriteConfig, extraLabels,
 			))
 		}
 	}

--- a/exporter/sinks/prom.go
+++ b/exporter/sinks/prom.go
@@ -11,21 +11,24 @@ import (
 	"github.com/castai/egressd/exporter/config"
 	"github.com/castai/egressd/pb"
 	"github.com/castai/promwrite"
+	"fmt"
+	"strings"
 )
 
 type promWriter interface {
 	Write(ctx context.Context, req *promwrite.WriteRequest, options ...promwrite.WriteOption) (*promwrite.WriteResponse, error)
 }
 
-func NewPromRemoteWriteSink(log logrus.FieldLogger, sinkName string, cfg config.SinkPromRemoteWriteConfig) Sink {
+func NewPromRemoteWriteSink(log logrus.FieldLogger, sinkName string, cfg config.SinkPromRemoteWriteConfig, extraLabels ExtraLabels) Sink {
 	return &PromRemoteWriteSink{
 		log: log.WithFields(map[string]interface{}{
 			"sink_type": "prom_remote_write",
 			"sink_name": sinkName,
 		}),
-		client:     promwrite.NewClient(cfg.URL),
-		timeGetter: timeGetter,
-		cfg:        cfg,
+		client:      promwrite.NewClient(cfg.URL),
+		timeGetter:  timeGetter,
+		cfg:         cfg,
+		extraLabels: extraLabels,
 	}
 }
 
@@ -34,10 +37,11 @@ func timeGetter() time.Time {
 }
 
 type PromRemoteWriteSink struct {
-	cfg        config.SinkPromRemoteWriteConfig
-	log        logrus.FieldLogger
-	client     promWriter
-	timeGetter func() time.Time
+	cfg         config.SinkPromRemoteWriteConfig
+	log         logrus.FieldLogger
+	client      promWriter
+	timeGetter  func() time.Time
+	extraLabels ExtraLabels
 }
 
 func (s *PromRemoteWriteSink) Push(ctx context.Context, batch *pb.PodNetworkMetricBatch) error {
@@ -50,25 +54,30 @@ func (s *PromRemoteWriteSink) Push(ctx context.Context, batch *pb.PodNetworkMetr
 		if dstIP.IsPrivate() {
 			dstIPType = "private"
 		}
+		labels := []promwrite.Label{
+			{Name: "__name__", Value: "egressd_transmit_bytes_total"},
+			{Name: "src_pod", Value: m.SrcPod},
+			{Name: "src_node", Value: m.SrcNode},
+			{Name: "src_namespace", Value: m.SrcNamespace},
+			{Name: "src_zone", Value: m.SrcZone},
+			{Name: "src_ip", Value: m.SrcIp},
+
+			{Name: "dst_pod", Value: m.DstPod},
+			{Name: "dst_node", Value: m.DstNode},
+			{Name: "dst_namespace", Value: m.DstNamespace},
+			{Name: "dst_zone", Value: m.DstZone},
+			{Name: "dst_ip", Value: dstIP.String()},
+			{Name: "dst_ip_type", Value: dstIPType},
+			{Name: "cross_zone", Value: isCrossZoneValue(m)},
+
+			{Name: "proto", Value: protoString(uint8(m.Proto))},
+		}
+		// add any defined extra labels
+		for k, v := range s.extraLabels {
+			labels = append(labels, promwrite.Label{Name: k, Value: v})
+		}
 		ts = append(ts, promwrite.TimeSeries{
-			Labels: []promwrite.Label{
-				{Name: "__name__", Value: "egressd_transmit_bytes_total"},
-				{Name: "src_pod", Value: m.SrcPod},
-				{Name: "src_node", Value: m.SrcNode},
-				{Name: "src_namespace", Value: m.SrcNamespace},
-				{Name: "src_zone", Value: m.SrcZone},
-				{Name: "src_ip", Value: m.SrcIp},
-
-				{Name: "dst_pod", Value: m.DstPod},
-				{Name: "dst_node", Value: m.DstNode},
-				{Name: "dst_namespace", Value: m.DstNamespace},
-				{Name: "dst_zone", Value: m.DstZone},
-				{Name: "dst_ip", Value: dstIP.String()},
-				{Name: "dst_ip_type", Value: dstIPType},
-				{Name: "cross_zone", Value: isCrossZoneValue(m)},
-
-				{Name: "proto", Value: protoString(uint8(m.Proto))},
-			},
+			Labels: labels,
 			Sample: promwrite.Sample{
 				Time:  now,
 				Value: float64(m.TxBytes),
@@ -104,4 +113,25 @@ func protoString(p uint8) string {
 		return protoNames[p]
 	}
 	return strconv.Itoa(int(p))
+}
+
+// ExtraLabels is a custom type that implements the flag.Value interface
+type ExtraLabels map[string]string
+
+// String is part of the flag.Value interface
+func (l *ExtraLabels) String() string {
+	return fmt.Sprint(*l)
+}
+
+// Set is part of the flag.Value interface
+// It parses a key=value pair and adds it to the map
+func (l *ExtraLabels) Set(value string) error {
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid label format: %s", value)
+	}
+	key := parts[0]
+	val := parts[1]
+	(*l)[key] = val
+	return nil
 }

--- a/exporter/sinks/prom_test.go
+++ b/exporter/sinks/prom_test.go
@@ -82,6 +82,82 @@ func TestPromSink(t *testing.T) {
 		client.req.TimeSeries)
 }
 
+func TestPromSinkWithExtraLabels(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+	extraLabels := ExtraLabels{
+		"extra1": "value1",
+		"extra2": "value2",
+	}
+
+	cfg := config.SinkPromRemoteWriteConfig{
+		URL: "prom-remote-write-url",
+		Headers: map[string]string{
+			"Custom-Header": "1",
+		},
+	}
+	client := &mockPromWriteClient{}
+	ts := time.Date(2023, time.April, 13, 13, 41, 48, 926278000, time.UTC)
+	sink := PromRemoteWriteSink{
+		cfg:    cfg,
+		log:    log,
+		client: client,
+		timeGetter: func() time.Time {
+			return ts
+		},
+		extraLabels: extraLabels,
+	}
+	batch := &pb.PodNetworkMetricBatch{
+		Items: []*pb.PodNetworkMetric{
+			{
+				SrcIp:        "10.14.7.12",
+				SrcPod:       "p1",
+				SrcNamespace: "team1",
+				SrcNode:      "n1",
+				SrcZone:      "us-east-1a",
+				DstIp:        "10.14.7.5",
+				DstPod:       "p2",
+				DstNamespace: "team2",
+				DstNode:      "n1",
+				DstZone:      "us-east-1a",
+				TxBytes:      35,
+				TxPackets:    3,
+				RxBytes:      30,
+				RxPackets:    1,
+				Proto:        6,
+			},
+		},
+	}
+	r.NoError(sink.Push(ctx, batch))
+
+	r.Equal([]promwrite.TimeSeries{
+		{
+			Labels: []promwrite.Label{
+				{Name: "__name__", Value: "egressd_transmit_bytes_total"},
+				{Name: "src_pod", Value: "p1"},
+				{Name: "src_node", Value: "n1"},
+				{Name: "src_namespace", Value: "team1"},
+				{Name: "src_zone", Value: "us-east-1a"},
+				{Name: "src_ip", Value: "10.14.7.12"},
+				{Name: "dst_pod", Value: "p2"},
+				{Name: "dst_node", Value: "n1"},
+				{Name: "dst_namespace", Value: "team2"},
+				{Name: "dst_zone", Value: "us-east-1a"},
+				{Name: "dst_ip", Value: "10.14.7.5"},
+				{Name: "dst_ip_type", Value: "private"},
+				{Name: "cross_zone", Value: "false"},
+				{Name: "proto", Value: "TCP"},
+				{Name: "extra1", Value: "value1"},
+				{Name: "extra2", Value: "value2"},
+			},
+			Sample: promwrite.Sample{Time: ts, Value: 35},
+		},
+	},
+		client.req.TimeSeries)
+}
+
 type mockPromWriteClient struct {
 	req *promwrite.WriteRequest
 }


### PR DESCRIPTION
# Description
When pushing to a prometheus remote-writer (or thanos receiver) one might want to add some extra-labels that the exporter always adds to every metric when it is pushed to the remote.

This PR adds a new property `-extra-label=key=value` to the exporter commandline. The property can be passed multiple times to add more than one label.

In the Helm chart, it can be set via:
```yaml
exporter:
  extraLabels:
    mylabel: myvalue
```