### PR TITLE
Add collector fetch timeout

### DIFF
--- a/exporter/config/config.go
+++ b/exporter/config/config.go
@@ -10,10 +10,12 @@ import (
 )
 
 type Config struct {
-	PodIP          string          `envconfig:"POD_IP" yaml:"podIP"`
-	PodNamespace   string          `envconfig:"POD_NAMESPACE" yaml:"podNamespace"`
-	ExportInterval time.Duration   `envconfig:"EXPORT_INTERVAL" yaml:"exportInterval"`
-	Sinks          map[string]Sink `yaml:"sinks"`
+	PodIP                          string          `envconfig:"POD_IP" yaml:"podIP"`
+	PodNamespace                   string          `envconfig:"POD_NAMESPACE" yaml:"podNamespace"`
+	ExportInterval                 time.Duration   `envconfig:"EXPORT_INTERVAL" yaml:"exportInterval"`
+	CollectorsConcurrentFetchCount int             `envconfig:"COLLECTORS_CONCURRENT_FETCH_COUNT" yaml:"collectorsConcurrentFetchCount"`
+	CollectorFetchTimeout          time.Duration   `envconfig:"COLLECTOR_FETCH_TIMEOUT" yaml:"collectorFetchTimeout"`
+	Sinks                          map[string]Sink `yaml:"sinks"`
 }
 
 type SinkType string
@@ -75,6 +77,12 @@ func Load(configPath string) (Config, error) {
 
 	if cfg.ExportInterval == 0 {
 		cfg.ExportInterval = 60 * time.Second
+	}
+	if cfg.CollectorsConcurrentFetchCount == 0 {
+		cfg.CollectorsConcurrentFetchCount = 20
+	}
+	if cfg.CollectorFetchTimeout == 0 {
+		cfg.CollectorFetchTimeout = 3 * time.Second
 	}
 
 	if len(cfg.Sinks) == 0 {

--- a/exporter/config/config_test.go
+++ b/exporter/config/config_test.go
@@ -66,9 +66,11 @@ sinks:
 
 func newTestConfig() Config {
 	return Config{
-		PodIP:          "10.10.1.15",
-		PodNamespace:   "egressd",
-		ExportInterval: 60 * time.Second,
+		PodIP:                          "10.10.1.15",
+		PodNamespace:                   "egressd",
+		ExportInterval:                 60 * time.Second,
+		CollectorsConcurrentFetchCount: 20,
+		CollectorFetchTimeout:          3 * time.Second,
 		Sinks: map[string]Sink{
 			"castai": {
 				HTTPConfig: &SinkHTTPConfig{

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -145,7 +145,9 @@ func TestExporter(t *testing.T) {
 	sink := &mockSink{batch: make(chan *pb.PodNetworkMetricBatch)}
 
 	cfg := config.Config{
-		ExportInterval: 100 * time.Millisecond,
+		ExportInterval:                 100 * time.Millisecond,
+		CollectorFetchTimeout:          3 * time.Second,
+		CollectorsConcurrentFetchCount: 20,
 		Sinks: map[string]config.Sink{
 			"castai": {
 				HTTPConfig: &config.SinkHTTPConfig{},

--- a/exporter/sinks/prom_test.go
+++ b/exporter/sinks/prom_test.go
@@ -133,7 +133,7 @@ func TestPromSink(t *testing.T) {
 		r.Len(client.reqs, 2)
 
 		slices.SortFunc(client.reqs, func(a, b *promwrite.WriteRequest) int {
-			return strings.Compare(a.TimeSeries[0].Labels[0].Name, b.TimeSeries[0].Labels[0].Name)
+			return strings.Compare(a.TimeSeries[0].Labels[0].Value, b.TimeSeries[0].Labels[0].Value)
 		})
 
 		r.Equal([]promwrite.TimeSeries{


### PR DESCRIPTION
Some pods may be already removed during fetch. Instead of getting tcp connect timeout we should cancel request faster to not block fetching from other collectors.